### PR TITLE
Make sure the label is up before we animate down

### DIFF
--- a/ARFloatingLabelTextField/ARFloatingLabelTextField.m
+++ b/ARFloatingLabelTextField/ARFloatingLabelTextField.m
@@ -139,7 +139,7 @@ static UIColor *kDefaultPlaceholderColor;
 {
     if(self.text.length && _labelIsUp){
         [self animateTextLayerChangeColor:self.placeholderColor];
-    }else if(self.text.length == 0) {
+    }else if(self.text.length == 0 && _labelIsUp) {
         _labelIsUp = NO;
         [self animateTextLayerDown];
     }


### PR DESCRIPTION
if the field becomes first responder and then resigns even if text was never entered
the label will snap up & and animate down to placeholder position.
This just makes sure to check that the label is up before animating it down into the placeholder position
